### PR TITLE
Fix GitHub repository URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "description": "Homebridge plugin for IES/Xterra heat pump temperature monitoring",
   "author": "Keith",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Keith/homebridge-ies-heatpump#readme",
+  "homepage": "https://github.com/keiththompson/homebridge-ies-heatpump#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Keith/homebridge-ies-heatpump.git"
+    "url": "https://github.com/keiththompson/homebridge-ies-heatpump.git"
   },
   "bugs": {
-    "url": "https://github.com/Keith/homebridge-ies-heatpump/issues"
+    "url": "https://github.com/keiththompson/homebridge-ies-heatpump/issues"
   },
   "keywords": [
     "homebridge-plugin",


### PR DESCRIPTION
## Summary
- Update repository URLs from `Keith` to `keiththompson` to match actual repo owner
- Fixes OIDC trusted publisher authentication with npm

## Test plan
- [ ] Merge this PR
- [ ] Bump version and tag
- [ ] Verify npm publish succeeds via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)