### PR TITLE
feat: add automated CHANGELOG generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,30 @@ jobs:
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)"
             exit 1
           fi
+      - name: Generate CHANGELOG
+        run: npm run changelog
+      - name: Commit CHANGELOG
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "docs: update CHANGELOG for ${GITHUB_REF#refs/tags/}"
+          git push origin HEAD:latest
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NPM_CONFIG_PROVENANCE: true
+      - name: Read CHANGELOG for release
+        id: changelog
+        run: |
+          # Extract the latest version section from CHANGELOG
+          VERSION=${GITHUB_REF#refs/tags/v}
+          CONTENT=$(awk "/## \[${VERSION}\]/{flag=1; next} /## \[/{flag=0} flag" CHANGELOG.md)
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.content }}
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.0.23](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.23...v1.0.23)
+
+## [v1.0.23](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.22...v1.0.23) - 2025-11-28
+
+## [v1.0.22](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.21...v1.0.22) - 2025-11-28
+
+### Commits
+
+- add back env [`03ac206`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/03ac20622defab1de15eb0c5efbc417121a91990)
+
+## [v1.0.21](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.20...v1.0.21) - 2025-11-28
+
+### Commits
+
+- allow write to create releases [`f4e71f2`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/f4e71f27eb561425438c4d223dd5f3fe117a9fee)
+
+## [v1.0.20](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.19...v1.0.20) - 2025-11-27
+
+## [v1.0.19](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.18...v1.0.19) - 2025-11-27
+
+## [v1.0.18](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.17...v1.0.18) - 2025-11-27
+
+### Commits
+
+- fix for v22 [`7c6abc4`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/7c6abc4e183612b371a600be328e3f567c01eaea)
+
+## [v1.0.17](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.16...v1.0.17) - 2025-11-27
+
+## [v1.0.16](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.15...v1.0.16) - 2025-11-27
+
+## [v1.0.15](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.14...v1.0.15) - 2025-11-27
+
+### Commits
+
+- more provo [`2636ef7`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/2636ef7f7dc4ef2bfb3cca712d8133a7d197c619)
+
+## [v1.0.14](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.13...v1.0.14) - 2025-11-27
+
+### Commits
+
+- provo [`91a4d52`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/91a4d52260c833a6a09a375fac48c1be5ef6d2af)
+
+## [v1.0.13](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.12...v1.0.13) - 2025-11-27
+
+### Commits
+
+- Remove cache, bump deps [`3935d44`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/3935d448e01c3d813fd9fafd2443c561f4d967d9)
+
+## [v1.0.12](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.11...v1.0.12) - 2025-11-27
+
+### Commits
+
+- pkg fix [`51fd678`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/51fd6782e85c9117e2026fb33bf33dfbb3f34451)
+
+## [v1.0.11](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.10...v1.0.11) - 2025-11-27
+
+### Commits
+
+- update release workflow [`69385af`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/69385af0b5e318c3454ad1771a7c5094ff76354a)
+
+## [v1.0.10](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.9...v1.0.10) - 2025-11-27
+
+### Commits
+
+- fix package.json [`7d14e47`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/7d14e4748e74518180e3c5d9d88a95d2c4e72650)
+
+## [v1.0.9](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.8...v1.0.9) - 2025-11-27
+
+## [v1.0.8](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.7...v1.0.8) - 2025-11-27
+
+### Commits
+
+- Remove environmentc [`450d6b4`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/450d6b48b518bd48ab935b61f66f98c4e24c25d0)
+
+## [v1.0.7](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.6...v1.0.7) - 2025-11-27
+
+## [v1.0.6](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.5...v1.0.6) - 2025-11-27
+
+## [v1.0.5](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.4...v1.0.5) - 2025-11-27
+
+## [v1.0.4](https://github.com/keiththompson/homebridge-ies-heatpump/compare/v1.0.2...v1.0.4) - 2025-11-27
+
+### Merged
+
+- Fix GitHub repository URLs in package.json [`#3`](https://github.com/keiththompson/homebridge-ies-heatpump/pull/3)
+
+## v1.0.2 - 2025-11-27
+
+### Merged
+
+- add tests [`#2`](https://github.com/keiththompson/homebridge-ies-heatpump/pull/2)
+- Replace cookie-based auth with OAuth login flow [`#1`](https://github.com/keiththompson/homebridge-ies-heatpump/pull/1)
+
+### Commits
+
+- Initial commit [`c5fa9e0`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/c5fa9e0dc8a1551518debfe1ebbc816be17bc9db)
+- Implement MVP: read-only temperature sensors [`1c51b74`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/1c51b74f9561130a0dd29a36b48c613061676c76)
+- no cookie [`a8ae642`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/a8ae6420ba439daccaefbcb0b7b3888f84564598)
+- Update README with plugin documentation [`568b1c6`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/568b1c69483d089fcf7d5056690dae13f1bd9d43)
+- Add debug logging to show available paramIds [`0a22687`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/0a226875082fc890ce15c4440c82ac18875373bf)
+- Add Hot Water Thermostat accessory [`e279341`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/e279341d551ad5e12628de713da3c30ee9fba707)
+- Add Season Mode accessory for Summer/Winter/Auto switching [`3ac88d4`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/3ac88d44bf1a8f7536cc340478dbc239473aad02)
+- Split Season Mode into 3 separate accessories [`c8d1843`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/c8d1843d3943cd7bd0ea9ff090349f47e5248e39)
+- Add Heating Room Setpoint accessory [`41bd40b`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/41bd40b9878521ac1f0caaf08214370e0b90621c)
+- Add Curve Offset accessory for heating curve adjustment [`171cf5c`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/171cf5c4234f890054319df3b75d02686a7ecfce)
+- Change Season Mode to 3 switches instead of thermostat [`deb2bc9`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/deb2bc90069ebe21361df7c2eae962733609f12a)
+- Update LICENSE [`b30d9c9`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/b30d9c999671a149de0940b09120b97fa6ed234b)
+- Implement hot water setpoint write capability [`be00b62`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/be00b6210234312a7cf505497a69d71d15ee4237)
+- Add tag-based release workflow [`3749009`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/37490092b8b82d2dbf7d227dd88627345eb25e31)
+- Fetch from both monitoring and settings endpoints [`f12a0d7`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/f12a0d78cc2e048e328a018bfa5df403aa44615e)
+- Fix security issues in debug logs and update README [`2ec6711`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/2ec67110579759c91184509a592be92d7f4d7676)
+- Fix API parsing: use viewParameters and id fields [`30e2bd0`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/30e2bd086e5593e6943a5818161e74cac76c3096)
+- Fix POST form to include all required fields [`846d84f`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/846d84fa0349b74a49cb53756715e5292fad50a9)
+- Remove Off/Heat modes from Hot Water - only Auto supported [`ace073c`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/ace073cd816c936e3112ab5de616050f35b9c741)
+- Add debug logging and fix value format for POST [`9b3cc7f`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/9b3cc7f7daf5c3e3a82d17d9380da4fa41df2303)
+- Detect session expiry on POST redirect to login [`bf91491`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/bf914915c16f8da89e94be59b9772718c4e3757d)
+- Use whole numbers for hot water setpoint, clean up debug logging [`150d6a1`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/150d6a19c70906285fde288eddcf5b3bf9997c30)
+- Add debug logging for CSRF fetch redirect detection [`33e5951`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/33e595137298f31fd0ed3f18014288226683d9f9)
+- Add detailed API response logging for debugging [`986ce49`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/986ce49615814288761c508dcee4030a25bef894)
+- Remove Flow and Return temperature sensors [`c5943df`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/c5943df754aaf09afb85757023ecaa8138195cc1)
+- Add debug logging for CSRF token search [`b928279`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/b92827910e007523d0b64cbb00cb9a30a2525514)
+- Temporarily use info level for POST debugging [`9f914d8`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/9f914d857e5db5804e8f56b624ef5f7d2f7bd837)
+- Extend temperature range to show actual API values [`b1357ad`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/b1357ad85a4ca839fe0d2cacd2e2cb3044fc286d)
+- Try /Configurations/ path instead of /main/configurations/ for CSRF [`e1e2e7f`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/e1e2e7f44d4e928800985d577feaffe4192f0d11)
+- add badges [`2d20ef0`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/2d20ef0573c8ff084148616f6b3ebe107f5db764)
+- Refresh values immediately after successful write [`65aed6b`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/65aed6b9e2534a61ba63a887e51c07cf893d0b67)
+- Remove stale TODO comment - API write is implemented [`0d0bc52`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/0d0bc52491accdd218795d22fca17a46180f2587)
+- Log group keys and content for debugging [`ed323b4`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/ed323b4e5cd732b29794fe4c003a07b9250a7b11)
+- Add npm environment to release workflow [`fa1b1f5`](https://github.com/keiththompson/homebridge-ies-heatpump/commit/fa1b1f50857033a65dec3fd14e85e26be8a96685)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^9.39.1",
         "@types/node": "^24.10.1",
         "@vitest/coverage-v8": "^4.0.14",
+        "auto-changelog": "^2.5.0",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -2108,6 +2109,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/auto-changelog": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
+      "integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "import-cwd": "^3.0.0",
+        "node-fetch": "^2.6.1",
+        "parse-github-url": "^1.0.3",
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "auto-changelog": "src/index.js"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/auto-changelog/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3667,6 +3699,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/hap-nodejs": {
       "version": "2.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-2.0.0-beta.2.tgz",
@@ -3872,6 +3926,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3887,6 +3954,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-from/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/imurmurhash": {
@@ -4959,6 +5049,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-persist": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
@@ -5259,6 +5377,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-github-url": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
+      "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parse-github-url": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/path-exists": {
@@ -6428,6 +6559,13 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6639,6 +6777,20 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6898,6 +7050,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7029,6 +7199,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,16 @@
     "validate": "npm run typecheck && npm run lint && npm run test",
     "prepublishOnly": "npm run validate && npm run build",
     "prepare": "husky",
-    "watch": "npm run build && npm link && nodemon"
+    "watch": "npm run build && npm link && nodemon",
+    "changelog": "auto-changelog -p"
+  },
+  "auto-changelog": {
+    "output": "CHANGELOG.md",
+    "template": "keepachangelog",
+    "unreleased": true,
+    "commitLimit": false,
+    "backfillLimit": false,
+    "hideCredit": true
   },
   "lint-staged": {
     "*.{ts,js}": [
@@ -59,6 +68,7 @@
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",
     "@vitest/coverage-v8": "^4.0.14",
+    "auto-changelog": "^2.5.0",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
## Summary

- Add `auto-changelog` package for generating CHANGELOG from git history
- Configure keepachangelog template format in `package.json`
- Update release workflow to generate and commit CHANGELOG on release
- Use CHANGELOG content for GitHub release notes instead of auto-generated
- Generate initial CHANGELOG with full version history (22 releases)

## How it works

On release (when a `v*` tag is pushed):
1. Workflow generates CHANGELOG from git history
2. Commits `CHANGELOG.md` back to `latest` branch
3. Extracts release notes for current version
4. Publishes to npm
5. Creates GitHub release with changelog content as body

## New npm script

```bash
npm run changelog  # Manually regenerate CHANGELOG if needed
```

## Test plan

- [x] `npm run validate` passes
- [ ] Verify CHANGELOG generates correctly on next release

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)