### PR TITLE
feat: add Compensation Type and Min Heating Setpoint accessories

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -669,6 +669,34 @@ export class IESClient {
   }
 
   /**
+   * Set the compensation type
+   * @param type 0-7 representing different compensation modes
+   */
+  async setCompensationType(type: number): Promise<void> {
+    this.log.info(`Setting compensation type to ${type}`);
+
+    const csrfToken = await this.fetchCsrfToken();
+
+    // This is a select field, so we send the numeric value as a string
+    await this.postSetting('_USER_HeatSPCtrl_Type_C', type.toString(), csrfToken);
+  }
+
+  /**
+   * Set the minimum heating setpoint
+   * @param temperature 0-70°C
+   */
+  async setMinHeatingSetpoint(temperature: number): Promise<void> {
+    this.log.info(`Setting min heating setpoint to ${temperature}°C`);
+
+    const csrfToken = await this.fetchCsrfToken();
+
+    // Format value with decimal (API expects "30.0" not "30")
+    const valueStr = temperature.toFixed(1);
+
+    await this.postSetting('_USER_Heating_SetPointMin_T', valueStr, csrfToken);
+  }
+
+  /**
    * Fetch CSRF token from the configurations page (uses session cookies)
    */
   private async fetchCsrfToken(retryOnAuth = true): Promise<string> {

--- a/src/compensationTypeAccessory.ts
+++ b/src/compensationTypeAccessory.ts
@@ -1,0 +1,98 @@
+import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+
+import type { IESHeatPumpPlatform } from './platform.js';
+
+/**
+ * Compensation Type Switch Accessory
+ * A single switch for one compensation type option
+ */
+export class CompensationTypeSwitchAccessory {
+  private readonly service: Service;
+  public readonly accessory: PlatformAccessory;
+  public readonly typeValue: number;
+  public readonly typeName: string;
+
+  constructor(
+    private readonly platform: IESHeatPumpPlatform,
+    accessory: PlatformAccessory,
+    typeValue: number,
+    typeName: string,
+    private readonly onSetType: (type: number) => Promise<void>,
+    private readonly getCurrentType: () => number,
+  ) {
+    this.accessory = accessory;
+    this.typeValue = typeValue;
+    this.typeName = typeName;
+
+    // Set accessory information
+    this.accessory
+      .getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'IES')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Compensation Type')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, `comp-type-${typeValue}`);
+
+    // Remove any old services that might be cached
+    const oldThermostat = this.accessory.getService(this.platform.Service.Thermostat);
+    if (oldThermostat) {
+      this.accessory.removeService(oldThermostat);
+    }
+
+    // Get or create Switch service
+    this.service =
+      this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch);
+
+    this.service.setCharacteristic(this.platform.Characteristic.Name, typeName);
+
+    this.service
+      .getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+
+    this.platform.log.debug(`Initialized Compensation Type switch: ${typeName}`);
+  }
+
+  private async getOn(): Promise<CharacteristicValue> {
+    return this.getCurrentType() === this.typeValue;
+  }
+
+  private async setOn(value: CharacteristicValue): Promise<void> {
+    const isOn = value as boolean;
+
+    if (isOn) {
+      // Turning this type on
+      if (this.getCurrentType() !== this.typeValue) {
+        this.platform.log.info(`Setting compensation type to ${this.typeName}`);
+        await this.onSetType(this.typeValue);
+      }
+    } else {
+      // Don't allow turning off the active type - revert it
+      if (this.getCurrentType() === this.typeValue) {
+        setTimeout(() => {
+          this.service.updateCharacteristic(this.platform.Characteristic.On, true);
+        }, 100);
+      }
+    }
+  }
+
+  /**
+   * Update switch state based on current type
+   */
+  updateState(currentType: number): void {
+    this.service.updateCharacteristic(this.platform.Characteristic.On, currentType === this.typeValue);
+  }
+
+  setUnavailable(): void {
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.StatusFault,
+      this.platform.Characteristic.StatusFault.GENERAL_FAULT,
+    );
+  }
+
+  clearFault(): void {
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.StatusFault,
+      this.platform.Characteristic.StatusFault.NO_FAULT,
+    );
+  }
+}

--- a/src/minHeatingSetpointAccessory.ts
+++ b/src/minHeatingSetpointAccessory.ts
@@ -1,0 +1,130 @@
+import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+
+import type { IESHeatPumpPlatform } from './platform.js';
+
+/**
+ * Min Heating Setpoint Accessory
+ * Exposes a HomeKit Thermostat service for adjusting the minimum heating setpoint
+ * Range: 0 to 70°C
+ */
+export class MinHeatingSetpointAccessory {
+  private readonly service: Service;
+  public readonly accessory: PlatformAccessory;
+
+  // Current state
+  private currentSetpoint = 30;
+
+  // Setpoint range from API
+  private readonly minSetpoint = 0;
+  private readonly maxSetpoint = 70;
+
+  constructor(
+    private readonly platform: IESHeatPumpPlatform,
+    accessory: PlatformAccessory,
+  ) {
+    this.accessory = accessory;
+
+    // Set accessory information
+    this.accessory
+      .getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'IES')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Heating Control')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'min-heating-setpoint');
+
+    // Get or create Thermostat service
+    this.service =
+      this.accessory.getService(this.platform.Service.Thermostat) ||
+      this.accessory.addService(this.platform.Service.Thermostat);
+
+    // Set display name
+    this.service.setCharacteristic(this.platform.Characteristic.Name, 'Min Heating Setpoint');
+
+    // Configure Current Temperature (shows current setpoint)
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature).setProps({
+      minValue: this.minSetpoint,
+      maxValue: this.maxSetpoint,
+    });
+
+    // Configure Target Temperature (settable setpoint)
+    this.service
+      .getCharacteristic(this.platform.Characteristic.TargetTemperature)
+      .setProps({
+        minValue: this.minSetpoint,
+        maxValue: this.maxSetpoint,
+        minStep: 1,
+      })
+      .onGet(this.getTargetSetpoint.bind(this))
+      .onSet(this.setTargetSetpoint.bind(this));
+
+    // Only AUTO mode
+    this.service.getCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState).setProps({
+      validValues: [this.platform.Characteristic.CurrentHeatingCoolingState.OFF],
+    });
+
+    this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState).setProps({
+      validValues: [this.platform.Characteristic.TargetHeatingCoolingState.AUTO],
+    });
+
+    // Set target state to AUTO
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.TargetHeatingCoolingState,
+      this.platform.Characteristic.TargetHeatingCoolingState.AUTO,
+    );
+
+    // Set current state to OFF
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.CurrentHeatingCoolingState,
+      this.platform.Characteristic.CurrentHeatingCoolingState.OFF,
+    );
+
+    this.platform.log.debug('Initialized Min Heating Setpoint accessory');
+  }
+
+  /**
+   * Update setpoint from API
+   */
+  updateSetpoint(value: number): void {
+    this.currentSetpoint = value;
+    this.service.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, value);
+    this.service.updateCharacteristic(this.platform.Characteristic.TargetTemperature, value);
+    this.platform.log.debug(`Min heating setpoint: ${value}°C`);
+  }
+
+  /**
+   * Get target setpoint for HomeKit
+   */
+  private async getTargetSetpoint(): Promise<CharacteristicValue> {
+    return this.currentSetpoint;
+  }
+
+  /**
+   * Set target setpoint from HomeKit
+   */
+  private async setTargetSetpoint(value: CharacteristicValue): Promise<void> {
+    const newSetpoint = value as number;
+    this.platform.log.info(`Setting min heating setpoint to ${newSetpoint}°C`);
+
+    this.currentSetpoint = newSetpoint;
+    await this.platform.setMinHeatingSetpoint(newSetpoint);
+  }
+
+  /**
+   * Mark as unavailable
+   */
+  setUnavailable(): void {
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.StatusFault,
+      this.platform.Characteristic.StatusFault.GENERAL_FAULT,
+    );
+  }
+
+  /**
+   * Clear fault status
+   */
+  clearFault(): void {
+    this.service.updateCharacteristic(
+      this.platform.Characteristic.StatusFault,
+      this.platform.Characteristic.StatusFault.NO_FAULT,
+    );
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,4 +57,30 @@ export const HEATING_ROOM_SETPOINT_PARAM = '_USER.HeatSPCtrl.TroomSet' as const;
  */
 export const SEASON_MODE_PARAM = '_USER.Parameters.SeasonMode' as const;
 
+/**
+ * Compensation Type parameter ID
+ * Values: 0-7 mapping to different compensation modes
+ */
+export const COMPENSATION_TYPE_PARAM = '_USER.HeatSPCtrl.Type' as const;
+
+/**
+ * Compensation Type options
+ */
+export const COMPENSATION_TYPES = [
+  { value: 0, name: 'Min', apiValue: 'TXT_TGT_AMB_COMP_MIN' },
+  { value: 1, name: 'Ambient', apiValue: 'TXT_TGT_AMB_COMP_AMBIENT' },
+  { value: 2, name: 'Room', apiValue: 'TXT_TGT_AMB_COMP_ROOM' },
+  { value: 3, name: 'Total', apiValue: 'TXT_TGT_AMB_COMP_TOTAL' },
+  { value: 4, name: 'Room On/Off', apiValue: 'TXT_TGT_AMB_COMP_ROOM_ONOFF' },
+  { value: 5, name: 'Ambient Mixing', apiValue: 'TXT_TGT_AMB_COMP_AMBIENT_MIXING' },
+  { value: 6, name: 'Room Mixing', apiValue: 'TXT_TGT_AMB_COMP_ROOM_MIXING' },
+  { value: 7, name: 'Total Mixing', apiValue: 'TXT_TGT_AMB_COMP_TOTAL_MIXING' },
+] as const;
+
+/**
+ * Min Heating Setpoint parameter ID
+ * Range: 0-70°C
+ */
+export const MIN_HEATING_SETPOINT_PARAM = '_USER.Heating.SetPointMin' as const;
+
 export type SensorDefinition = (typeof TEMPERATURE_SENSORS)[number];


### PR DESCRIPTION
## Summary
- Add 8 HomeKit switch accessories for Compensation Type (Min, Ambient, Room, Total, Room On/Off, Ambient Mixing, Room Mixing, Total Mixing)
- Add thermostat-style accessory for Min Heating Setpoint (0-70°C range)
- Includes API methods, polling updates, and fault handling for both new accessory types

## Test plan
- [ ] Verify new accessories appear in HomeKit after plugin restart
- [ ] Test switching between compensation types - only one should be active at a time
- [ ] Test adjusting min heating setpoint via Home app
- [ ] Verify values sync correctly from API polling
- [ ] Confirm error handling when API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)