### PR TITLE
feat: add debug logging for heat pump state

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -19,6 +19,7 @@ import type { SensorDefinition } from './settings.js';
 import {
   CURVE_OFFSET_PARAM,
   DEFAULT_POLLING_INTERVAL,
+  HEAT_PUMP_STATE_PARAM,
   HEATING_ROOM_SETPOINT_PARAM,
   HOT_WATER_PARAMS,
   MIN_HEATING_SETPOINT_PARAM,
@@ -447,6 +448,12 @@ export class IESHeatPumpPlatform implements DynamicPlatformPlugin {
           this.minHeatingSetpointAccessory.clearFault();
           this.minHeatingSetpointAccessory.updateSetpoint(setpoint.value);
         }
+      }
+
+      // Log heat pump state for analysis
+      const heatPumpState = readings.get(HEAT_PUMP_STATE_PARAM);
+      if (heatPumpState) {
+        this.log.debug(`Heat pump state: ${heatPumpState.raw}`);
       }
     } catch (error) {
       if (error instanceof IESApiError) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -63,4 +63,10 @@ export const SEASON_MODE_PARAM = '_USER.Parameters.SeasonMode' as const;
  */
 export const MIN_HEATING_SETPOINT_PARAM = '_USER.Heating.SetPointMin' as const;
 
+/**
+ * Heat Pump State parameter ID (for logging/analysis)
+ * Values: TXT_TGT_STATE1-29 (Ready, Heating, Hot water, Defrost, etc.)
+ */
+export const HEAT_PUMP_STATE_PARAM = '_USER.HeatPump.State' as const;
+
 export type SensorDefinition = (typeof TEMPERATURE_SENSORS)[number];


### PR DESCRIPTION
## Summary
- Add `HEAT_PUMP_STATE_PARAM` constant for `_USER.HeatPump.State` parameter
- Log heat pump state on each API poll cycle at debug level
- Enables analysis of operating modes (heating, hot water, defrost, etc.) over time

## Test plan
- [x] Build passes
- [x] All 109 tests pass
- [x] Enable debug logging in Homebridge UI and verify state appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)